### PR TITLE
Make gengen usable with "go generate".

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ source code and compile that into our projects.
 
 Get the `gengen` tool:
 
-    $ go get github.com/joeshaw/gengen
+    $ go get github.com/alecthomas/gengen
 
 Create a Go source file with a generic implementation.  For example,
 this contrived linked-list implementation in `list.go`:
@@ -24,7 +24,7 @@ this contrived linked-list implementation in `list.go`:
 ```go
 package list
 
-import "github.com/joeshaw/gengen/generic"
+import "github.com/alecthomas/gengen/generic"
 
 type List struct {
     data generic.T
@@ -233,7 +233,7 @@ Finally, generate your implementations:
 
 The `gengen` tool looks through the source code for specific strings
 in order to replace them in the AST.  Specifically, it looks for the
-import `github.com/joeshaw/gengen/generic` and the types `generic.T`,
+import `github.com/alecthomas/gengen/generic` and the types `generic.T`,
 `generic.U`, and `generic.V`.  If you need to change these, you will
 also have to change the `gengen.go` source.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ this contrived linked-list implementation in `list.go`:
 ```go
 package list
 
+//go:generate gengen -o list_string.go -r "List -> StringList" list.go string
 import "github.com/alecthomas/gengen/generic"
 
 type List struct {

--- a/examples/btree/btree.go
+++ b/examples/btree/btree.go
@@ -90,7 +90,7 @@ package main
 import (
 	"io"
 
-	"github.com/joeshaw/gengen/generic"
+	"github.com/alecthomas/gengen/generic"
 )
 
 //TODO check vs orig initialize/finalize

--- a/examples/list/list.go
+++ b/examples/list/list.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/joeshaw/gengen/generic"
+	"github.com/alecthomas/gengen/generic"
 )
 
 type List struct {

--- a/examples/slice/slice.go
+++ b/examples/slice/slice.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/joeshaw/gengen/generic"
+	"github.com/alecthomas/gengen/generic"
 )
 
 type MySlice []generic.T

--- a/gengen.go
+++ b/gengen.go
@@ -6,9 +6,12 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 
 	"code.google.com/p/go.tools/astutil"
+	"gopkg.in/alecthomas/kingpin.v1"
+	"labix.org/v2/pipe"
 )
 
 const pkgPath = "github.com/joeshaw/gengen/generic"
@@ -16,7 +19,7 @@ const genericPkg = "generic"
 
 var genericTypes = []string{"T", "U", "V"}
 
-func generate(filename string, typenames ...string) error {
+func generate(out io.Writer, filename string, typenames ...string) error {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
 	if err != nil {
@@ -47,20 +50,38 @@ func generate(filename string, typenames ...string) error {
 		astutil.DeleteImport(fset, f, pkgPath)
 	}
 
-	err = format.Node(os.Stdout, fset, f)
+	err = format.Node(out, fset, f)
 	return err
 }
 
+var (
+	outFileFlag  = kingpin.Flag("output", "Output to file (defaults to stdout).").Short('o').PlaceHolder("FILE").String()
+	rewritesFlag = kingpin.Flag("rewrite", "Rewrite clause for gofmt.").Short('r').Strings()
+	filenameArg  = kingpin.Arg("file.go", "Input template filename.").Required().ExistingFile()
+	typeArgs     = kingpin.Arg("replacement types...", "Types to substitute.").Required().Strings()
+)
+
 func main() {
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "usage: %s <file.go> <replacement types...>\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "example: %s list.go int string\n", os.Args[0])
-		os.Exit(1)
+	kingpin.CommandLine.Help = fmt.Sprintf("example: %s -o list_int_string.go list.go int string", kingpin.CommandLine.Name)
+	kingpin.Parse()
+
+	r, w, err := os.Pipe()
+	kingpin.FatalIfError(err, "")
+
+	p := pipe.Line(pipe.Read(r))
+	for _, rewrite := range *rewritesFlag {
+		p = pipe.Line(p, pipe.Exec("gofmt", "-r", rewrite))
+	}
+	if *outFileFlag != "" {
+		p = pipe.Line(p, pipe.WriteFile(*outFileFlag, 0666))
+	} else {
+		p = pipe.Line(p, pipe.Write(os.Stdout))
 	}
 
-	err := generate(os.Args[1], os.Args[2:]...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
-		os.Exit(1)
-	}
+	err = generate(w, *filenameArg, *typeArgs...)
+	w.Close()
+	kingpin.FatalIfError(err, "")
+
+	err = pipe.Run(p)
+	kingpin.FatalIfError(err, "")
 }

--- a/gengen.go
+++ b/gengen.go
@@ -14,7 +14,7 @@ import (
 	"labix.org/v2/pipe"
 )
 
-const pkgPath = "github.com/joeshaw/gengen/generic"
+const pkgPath = "github.com/alecthomas/gengen/generic"
 const genericPkg = "generic"
 
 var genericTypes = []string{"T", "U", "V"}
@@ -79,8 +79,8 @@ func main() {
 	}
 
 	err = generate(w, *filenameArg, *typeArgs...)
-	w.Close()
 	kingpin.FatalIfError(err, "")
+	w.Close()
 
 	err = pipe.Run(p)
 	kingpin.FatalIfError(err, "")


### PR DESCRIPTION
Fixes #3.

Supports -o <output> for specifying the output file, and -r <rewrite>
for applying gofmt rewrites.
