### PR TITLE
adds a separate "genpkg" executable

### DIFF
--- a/examples/btree/btree.go
+++ b/examples/btree/btree.go
@@ -85,7 +85,7 @@
 // getting the next or previous iterated item is performed in about 13-14 ns.
 // This is the nice O(1) property of B+trees usually not found in other tree
 // types.
-package main
+package btree
 
 import (
 	"io"

--- a/gengen.go
+++ b/gengen.go
@@ -4,60 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"go/ast"
-	"go/format"
-	"go/parser"
-	"go/token"
 	"io"
 	"io/ioutil"
 	"os"
 
-	"golang.org/x/tools/go/ast/astutil"
+	"github.com/joeshaw/gengen/genlib"
 )
-
-const pkgPath = "github.com/joeshaw/gengen/generic"
-const genericPkg = "generic"
-
-var genericTypes = []string{"T", "U", "V"}
-
-func generate(filename string, typenames ...string) ([]byte, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
-	if err != nil {
-		return nil, err
-	}
-
-	f = replace(func(node ast.Node) ast.Node {
-		se, ok := node.(*ast.SelectorExpr)
-		if !ok {
-			return node
-		}
-
-		x, ok := se.X.(*ast.Ident)
-		if !ok || x.Name != genericPkg {
-			return node
-		}
-
-		for i, t := range genericTypes {
-			if se.Sel.Name == t {
-				return &ast.Ident{NamePos: 0, Name: typenames[i]}
-			}
-		}
-
-		return node
-	}, f).(*ast.File)
-
-	if !astutil.UsesImport(f, pkgPath) {
-		astutil.DeleteImport(fset, f, pkgPath)
-	}
-
-	var buf bytes.Buffer
-	if err = format.Node(&buf, fset, f); err != nil {
-		return nil, err
-	}
-
-	return format.Source(buf.Bytes())
-}
 
 func main() {
 	var outfile = flag.String("o", "", "output file")
@@ -69,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	buf, err := generate(flag.Arg(0), flag.Args()[1:]...)
+	buf, err := genlib.Generate(flag.Arg(0), flag.Args()[1:]...)
 	if err != nil {
 		die(err)
 	}

--- a/genlib/generate.go
+++ b/genlib/generate.go
@@ -1,0 +1,55 @@
+package genlib
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+const pkgPath = "github.com/joeshaw/gengen/generic"
+const genericPkg = "generic"
+
+var genericTypes = []string{"T", "U", "V"}
+
+func Generate(filename string, typenames ...string) ([]byte, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	f = replace(func(node ast.Node) ast.Node {
+		se, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return node
+		}
+
+		x, ok := se.X.(*ast.Ident)
+		if !ok || x.Name != genericPkg {
+			return node
+		}
+
+		for i, t := range genericTypes {
+			if se.Sel.Name == t {
+				return &ast.Ident{NamePos: 0, Name: typenames[i]}
+			}
+		}
+
+		return node
+	}, f).(*ast.File)
+
+	if !astutil.UsesImport(f, pkgPath) {
+		astutil.DeleteImport(fset, f, pkgPath)
+	}
+
+	var buf bytes.Buffer
+	if err = format.Node(&buf, fset, f); err != nil {
+		return nil, err
+	}
+
+	return format.Source(buf.Bytes())
+}

--- a/genlib/replace.go
+++ b/genlib/replace.go
@@ -5,7 +5,7 @@
 // This file was copied from github.com/jessevdk/go-operators,
 // which itself was forked from go/ast walk.go.
 
-package main
+package genlib
 
 import (
 	"fmt"

--- a/genpkg/main.go
+++ b/genpkg/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/joeshaw/gengen/genlib"
+)
+
+func main() {
+	var outdir = flag.String("o", ".", "output directory")
+	flag.Parse()
+
+	if flag.NArg() < 2 {
+		cmd := os.Args[0]
+		fmt.Fprintf(os.Stderr, "usage: %s [-o <output_dir>] <package> <replacement types...>\n", cmd)
+		fmt.Fprintf(os.Stderr, "example: %s -o ./btree github.com/joeshaw/gengen/examples/btree string string\n", cmd)
+		os.Exit(1)
+	}
+
+	types := make([]string, flag.NArg()-1)
+	for i := 1; i < flag.NArg(); i++ {
+		types[i-1] = flag.Arg(i)
+	}
+
+	// run a "go get <pkg>"
+	err := exec.Command("go", "get", flag.Arg(0)).Run()
+	if err != nil {
+		die(err)
+	}
+
+	// resolve the path into which we (might have) just installed it
+	pkgpath := findPkgPath(flag.Arg(0))
+	if pkgpath == "" {
+		die(fmt.Errorf("couldn't find %s", flag.Arg(0)))
+	}
+
+	// list the source files
+	sourcefiles, err := filepath.Glob(path.Join(pkgpath, "*.go"))
+	if err != nil {
+		die(err)
+	}
+
+	// create a temporary directory
+	tdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		die(err)
+	}
+
+	// convert all source files into the tmp dir
+	for _, source_path := range sourcefiles {
+		dest_path := path.Join(tdir, path.Base(source_path))
+		err := convertFile(dest_path, source_path, types...)
+		if err != nil {
+			die(err)
+		}
+	}
+
+	// move the converted files into our output dir
+	replaceFiles(tdir, *outdir)
+
+	// remove the temporary directory
+	os.RemoveAll(tdir)
+}
+
+func convertFile(dest_path, source_path string, types ...string) error {
+	buf, err := genlib.Generate(source_path, types...)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(dest_path)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(f, bytes.NewBuffer(buf))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func replaceFiles(source_dir, dest_dir string) {
+	sources, err := filepath.Glob(path.Join(source_dir, "*.go"))
+	if err != nil {
+		die(err)
+	}
+
+	if !exists(dest_dir) {
+		os.MkdirAll(dest_dir, 0755)
+	}
+
+	for _, source := range sources {
+		dest := path.Join(dest_dir, path.Base(source))
+		if err := os.Rename(source, dest); err != nil {
+			if patherr, ok := err.(*os.LinkError); ok {
+				if errno, ok := patherr.Err.(syscall.Errno); ok {
+					if errno == syscall.EXDEV {
+						if err = copyBytes(source, dest); err == nil {
+							continue
+						}
+					}
+				}
+			}
+			die(err)
+		}
+	}
+}
+
+func copyBytes(source, dest string) error {
+	sfile, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sfile.Close()
+
+	dfile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer dfile.Close()
+
+	_, err = io.Copy(dfile, sfile)
+	return err
+}
+
+func findPkgPath(name string) string {
+	for _, dir := range strings.Split(os.Getenv("GOPATH"), ";") {
+		fullpath := path.Join(dir, "src", name)
+		if exists(fullpath) {
+			return fullpath
+		}
+	}
+	return ""
+}
+
+func exists(fpath string) bool {
+	_, err := os.Stat(fpath)
+	return !os.IsNotExist(err)
+}
+
+func die(err error) {
+	fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
genpkg takes a similar "-o" option, which in this case specifies an
output _directory_, then a package name and replacement types.

It calls out to "go get" to ensure the package is fetched, locates the
package according to $GOPATH, then effectively runs all the .go files
through gengen, dumping the output files to the output dir (which
defauls to the current directory).

The purpose is to enable type-agnostic datastructures and algorithms to
not just be _written_, but also _published_. Taking the btree package
from the examples/ directory, to get a subpackage of btree<string,int>
I could just put this in my project:

```
//go:generate genpkg -o ./btree github.com/joeshaw/gengen/examples/btree string int
```

Then "go generate" would fetch that third-party generic package and
codegen the type-specific package I need for my project from it.

To make this work I had to separate out the core functionality into a
"genlib" package so it could be imported into both utilities.
