### PR TITLE
Multi types

### DIFF
--- a/generic/generic.go
+++ b/generic/generic.go
@@ -12,3 +12,72 @@ type U interface{}
 
 // V is the third type substituted by the gengen tool
 type V interface{}
+
+// A is a generalize type used by the gengen tool
+type A interface{}
+
+// B is a generalize type used by the gengen tool
+type B interface{}
+
+// C is a generalize type used by the gengen tool
+type C interface{}
+
+// D is a generalize type used by the gengen tool
+type D interface{}
+
+// E is a generalize type used by the gengen tool
+type E interface{}
+
+// F is a generalize type used by the gengen tool
+type F interface{}
+
+// G is a generalize type used by the gengen tool
+type G interface{}
+
+// H is a generalize type used by the gengen tool
+type H interface{}
+
+// I is a generalize type used by the gengen tool
+type I interface{}
+
+// J is a generalize type used by the gengen tool
+type J interface{}
+
+// K is a generalize type used by the gengen tool
+type K interface{}
+
+// L is a generalize type used by the gengen tool
+type L interface{}
+
+// M is a generalize type used by the gengen tool
+type M interface{}
+
+// N is a generalize type used by the gengen tool
+type N interface{}
+
+// O is a generalize type used by the gengen tool
+type O interface{}
+
+// P is a generalize type used by the gengen tool
+type P interface{}
+
+// Q is a generalize type used by the gengen tool
+type Q interface{}
+
+// R is a generalize type used by the gengen tool
+type R interface{}
+
+// S is a generalize type used by the gengen tool
+type S interface{}
+
+// W is a generalize type used by the gengen tool
+type W interface{}
+
+// X is a generalize type used by the gengen tool
+type X interface{}
+
+// Y is a generalize type used by the gengen tool
+type Y interface{}
+
+// Z is a generalize type used by the gengen tool
+type Z interface{}

--- a/genlib/generate.go
+++ b/genlib/generate.go
@@ -13,9 +13,7 @@ import (
 const pkgPath = "github.com/joeshaw/gengen/generic"
 const genericPkg = "generic"
 
-var genericTypes = []string{"T", "U", "V"}
-
-func Generate(filename string, typenames ...string) ([]byte, error) {
+func Generate(filename string, lookup map[string]string) ([]byte, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
 	if err != nil {
@@ -32,11 +30,8 @@ func Generate(filename string, typenames ...string) ([]byte, error) {
 		if !ok || x.Name != genericPkg {
 			return node
 		}
-
-		for i, t := range genericTypes {
-			if se.Sel.Name == t {
-				return &ast.Ident{NamePos: 0, Name: typenames[i]}
-			}
+		if newName, ok := lookup[se.Sel.Name]; ok {
+			return &ast.Ident{NamePos: 0, Name: newName}
 		}
 
 		return node

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/tools/imports"
 )
 
+var defaultNames = []string{"T", "U", "V"}
+
 func main() {
 	var (
 		outDir     = flag.String("o", ".", "output directory")
@@ -29,9 +31,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	types := make([]string, flag.NArg()-1)
-	for i := 1; i < flag.NArg(); i++ {
-		types[i-1] = flag.Arg(i)
+	types := make(map[string]string)
+	typeCount := flag.NArg() - 1
+	if typeCount > len(defaultNames) {
+		typeCount = len(defaultNames)
+	}
+	for i, newName := range defaultNames[0:typeCount] {
+		types[newName] = flag.Arg(i + 1)
 	}
 
 	// run a "go get <pkg>"
@@ -61,7 +67,7 @@ func main() {
 	// convert all source files into the tmp dir
 	for _, sourcePath := range sourceFiles {
 		destPath := filepath.Join(tempDir, filepath.Base(sourcePath))
-		err := convertFile(destPath, sourcePath, *fixImports, types...)
+		err := convertFile(destPath, sourcePath, *fixImports, types)
 		if err != nil {
 			die(err)
 		}
@@ -74,8 +80,8 @@ func main() {
 	os.RemoveAll(tempDir)
 }
 
-func convertFile(destPath, sourcePath string, fixImports bool, types ...string) error {
-	buf, err := genlib.Generate(sourcePath, types...)
+func convertFile(destPath, sourcePath string, fixImports bool, types map[string]string) error {
+	buf, err := genlib.Generate(sourcePath, types)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow 26 different type aliases to be used.

This support the old positional alias syntax
```
./gengen -o ./btree github.com/joeshaw/gengen/examples/btree string string
```

Mix of named aliases and positional alias
```
./gengen -o ./btree github.com/joeshaw/gengen/examples/btree U=string string
./gengen -o ./btree github.com/joeshaw/gengen/examples/btree string U=string
```

Just aliases
```
./gengen -o ./btree github.com/joeshaw/gengen/examples/btree T=string U=string
```